### PR TITLE
Feat battle system

### DIFF
--- a/Assets/Scenes/0.IntegratedScene/IntegratedScene.unity
+++ b/Assets/Scenes/0.IntegratedScene/IntegratedScene.unity
@@ -1814,6 +1814,22 @@ PrefabInstance:
       propertyPath: m_text
       value: 5
       objectReference: {fileID: 0}
+    - target: {fileID: 9040190393381310516, guid: 2d2ab263df0f03642bb82ff7bf791f5c, type: 3}
+      propertyPath: m_Color.a
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 9040190393381310516, guid: 2d2ab263df0f03642bb82ff7bf791f5c, type: 3}
+      propertyPath: m_Color.b
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 9040190393381310516, guid: 2d2ab263df0f03642bb82ff7bf791f5c, type: 3}
+      propertyPath: m_Color.g
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 9040190393381310516, guid: 2d2ab263df0f03642bb82ff7bf791f5c, type: 3}
+      propertyPath: m_Color.r
+      value: 1
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []

--- a/Assets/Scenes/4.BattleScene/Scripts/UI/CardController.cs
+++ b/Assets/Scenes/4.BattleScene/Scripts/UI/CardController.cs
@@ -26,6 +26,7 @@ public class CardController : MonoBehaviour, IPointerEnterHandler, IPointerExitH
 
     GameObject cardDeck;
     private CardDeckController  cardDeckController;
+    private PlayerCard playerCard;
 
     public static GameObject card;
     public Canvas canvas;
@@ -40,6 +41,8 @@ public class CardController : MonoBehaviour, IPointerEnterHandler, IPointerExitH
         cardDeck = GameObject.Find("CardPanel");
         cardDeckController = cardDeck.GetComponent<CardDeckController>();
         rect = GetComponent<RectTransform>();
+        
+        playerCard = GetComponent<PlayerCard>();
         
         defaultPosition = transform.position;
         // defaultPosition = rect.anchoredPosition;
@@ -176,25 +179,25 @@ public class CardController : MonoBehaviour, IPointerEnterHandler, IPointerExitH
                 if (playerManager != null && playerManager.currentCost > 0)
                 {
                     Debug.Log($"{hitObj.name}의 현재 체력: {playerManager.currentHP}");
-                    int AP = transform.GetComponent<PlayerCard>().ap;
-                    int DP = transform.GetComponent<PlayerCard>().dp;
-                    int cost = transform.GetComponent<PlayerCard>().cost;
-                    // int cardAP = int.Parse(card.transform.Find("AttackPower/Text").GetComponent<TextMeshProUGUI>().text);
-                    // int cardDP = int.Parse(card.transform.Find("Defense/Text").GetComponent<TextMeshProUGUI>().text);
-                    // playerManager.attackPower += cardAP;
-                    // playerManager.defensePower += cardDP;
+                    int posValue = playerCard.posValue;
+                    int negValue = playerCard.negValue;
+                    int cost = playerCard.cost;
 
                     if (playerManager.currentCost < cost)
                     {
-                        // [TODO] current cost에 따라 사용 가능한 카드만 하이라이트 효과 적용
+                        // [TODO] current cost에 따라 사용 가능한 카드만 하이라이트 효과 적용 + 사용 불가능한 카드의 raycast 해제
                         Debug.Log("현재 코스트보다 큰 카드는 사용 불가");
                     }
                     else
                     {
                         // [TODO] 함수화 & 카드 속성에 따라 다르게 적용
-                        playerManager.attackPower += AP;
-                        playerManager.defensePower += DP;
+                        StatType posType = playerCard.cardData.positiveStatType;
+                        StatType negType = playerCard.cardData.negativeStatType;
+                        
+                        playerManager.AddTurnStatDelta(posType, posValue);
+                        playerManager.AddTurnStatDelta(negType, -negValue);
                         playerManager.currentCost = Mathf.Max(0, playerManager.currentCost - cost);
+                        
                         playerManager.UpdateUI();
                     }
                 }

--- a/Assets/Scenes/4.BattleScene/Scripts/UI/CardObject/ATK_001.asset
+++ b/Assets/Scenes/4.BattleScene/Scripts/UI/CardObject/ATK_001.asset
@@ -16,12 +16,9 @@ MonoBehaviour:
   cardName: "\uC548\uD2F0\uBC14\uC774\uB7EC\uC2A4 \uC2A4\uCE94"
   cardImage: {fileID: 21300000, guid: d91e93f8e08c23c4b9a1254826a9da94, type: 3}
   positiveStatType: 0
-  negativeStatType: 0
-  positiveIcon: {fileID: 0}
-  negativeIcon: {fileID: 0}
-  attackPower: 3
-  defensePower: -2
-  healthPoint: 0
+  negativeStatType: 1
+  positiveStatValue: 3
+  negativeStatValue: 2
   cost: 2
   description: "\uBC14\uC774\uB7EC\uC2A4\uB97C \uC0AD\uC81C\uD574 \uACF5\uACA9\uB825\uC774
-    \uAC15\uD654\uB41C\uB2E4."
+    \uAC15\uD654\uB41C\uB2E4.\n\uACF5\uACA9\uB825 +3 / \uBC29\uC5B4\uB825 -2"

--- a/Assets/Scenes/4.BattleScene/Scripts/UI/CardObject/ATK_002.asset
+++ b/Assets/Scenes/4.BattleScene/Scripts/UI/CardObject/ATK_002.asset
@@ -15,9 +15,11 @@ MonoBehaviour:
   cardIndex: 1
   cardName: "\uAC15\uC81C \uC885\uB8CC"
   cardImage: {fileID: 21300000, guid: d91e93f8e08c23c4b9a1254826a9da94, type: 3}
-  attackPower: 4
-  defensePower: 0
-  healthPoint: -3
+  positiveStatType: 0
+  negativeStatType: 3
+  positiveStatValue: 4
+  negativeStatValue: 3
   cost: 4
   description: "\uAC15\uC81C \uC885\uB8CC \uBA85\uB839\uC5B4\uB85C \uC801\uC744 \uD06C\uAC8C
-    \uD0C0\uACA9\uD55C\uB2E4."
+    \uD0C0\uACA9\uD55C\uB2E4.\n\uACF5\uACA9\uB825 +4 / \uCD5C\uB300 \uCCB4\uB825
+    -3"

--- a/Assets/Scenes/4.BattleScene/Scripts/UI/CardObject/DEF_001.asset
+++ b/Assets/Scenes/4.BattleScene/Scripts/UI/CardObject/DEF_001.asset
@@ -15,8 +15,10 @@ MonoBehaviour:
   cardIndex: 0
   cardName: "\uBC29\uD654\uBCBD \uC124\uCE58"
   cardImage: {fileID: 21300000, guid: d2f5dbeaf9828e24c8e8f552ec5610ec, type: 3}
-  attackPower: 0
-  defensePower: 0
-  healthPoint: 0
-  cost: 0
-  description: 
+  positiveStatType: 1
+  negativeStatType: 3
+  positiveStatValue: 2
+  negativeStatValue: 3
+  cost: 2
+  description: "\uBC29\uD654\uBCBD\uC744 \uC124\uCE58\uD574 \uD53C\uD574\uB97C \uC904\uC778\uB2E4.\n\uBC29\uC5B4\uB825
+    +2 / \uD68C\uD53C\uB825 -3"

--- a/Assets/Scenes/4.BattleScene/Scripts/UI/CardObject/HP_001.asset
+++ b/Assets/Scenes/4.BattleScene/Scripts/UI/CardObject/HP_001.asset
@@ -15,10 +15,11 @@ MonoBehaviour:
   cardIndex: 2
   cardName: "\uBCF4\uC548 \uC5C5\uB370\uC774\uD2B8"
   cardImage: {fileID: 21300000, guid: d91e93f8e08c23c4b9a1254826a9da94, type: 3}
-  attackPower: 0
-  defensePower: 0
-  healthPoint: 5
-  cost: 2
+  positiveStatType: 3
+  negativeStatType: 2
+  positiveStatValue: 5
+  negativeStatValue: 2
+  cost: 0
   description: "\uCD5C\uC2E0 \uBCF4\uC548 \uC5C5\uB370\uC774\uD2B8\uB85C \uCCB4\uB825\uC774
-    \uD5A5\uC0C1\uB41C\uB2E4.\n\uCD5C\uB300 \uCCB4\uB825 5 \uC99D\uAC00 / \uCD5C\uB300
-    \uCF54\uC2A4\uD2B8 2 \uAC10\uC18C"
+    \uD5A5\uC0C1\uB41C\uB2E4.\n\uCD5C\uB300 \uCCB4\uB825 +5 / \uCD5C\uB300 \uCF54\uC2A4\uD2B8
+    -2"

--- a/Assets/Scenes/4.BattleScene/Scripts/UI/CardObject/HP_002.asset
+++ b/Assets/Scenes/4.BattleScene/Scripts/UI/CardObject/HP_002.asset
@@ -15,9 +15,11 @@ MonoBehaviour:
   cardIndex: 2
   cardName: "\uAE34\uAE09 \uBCF5\uAD6C"
   cardImage: {fileID: 21300000, guid: d91e93f8e08c23c4b9a1254826a9da94, type: 3}
-  attackPower: 0
-  defensePower: -2
-  healthPoint: 3
+  positiveStatType: 3
+  negativeStatType: 1
+  positiveStatValue: 3
+  negativeStatValue: 2
   cost: 3
   description: "\uC2DC\uC2A4\uD15C \uBCF5\uAD6C \uBAA8\uB4DC\uB85C \uCCB4\uB825\uC774
-    \uD68C\uBCF5\uB41C\uB2E4."
+    \uD68C\uBCF5\uB41C\uB2E4.\n\uCD5C\uB300 \uCCB4\uB825 +3 / \uBC29\uC5B4\uB825
+    -2"

--- a/Assets/Scenes/4.BattleScene/Scripts/UI/PlayerCard.cs
+++ b/Assets/Scenes/4.BattleScene/Scripts/UI/PlayerCard.cs
@@ -19,13 +19,13 @@ public class PlayerCard : MonoBehaviour
     // 카드 설명 추가.
     private string description;
 
-    public int ap
+    public int posValue
     {
         get { return positiveStatValue; }
         set { positiveStatValue = value; }
     }
     
-    public int dp
+    public int negValue
     {
         get { return negativeStatValue; }
         set { negativeStatValue = value; }

--- a/Assets/Scenes/4.Enemy/Scripts/EnemyTurnManager.cs
+++ b/Assets/Scenes/4.Enemy/Scripts/EnemyTurnManager.cs
@@ -75,6 +75,10 @@ public class EnemyTurnManager : MonoBehaviour
 
         _running = false;
         
+        PlayerManager.instance.ResetTurnDeltaStats();
+        PlayerManager.instance.currentCost = PlayerManager.instance.TotalCost;
+        PlayerManager.instance.UpdateUI();
+        
         Debug.Log("적 턴 종료");
     }
     public void InitEnemyIntents()


### PR DESCRIPTION
add: 플레이어 턴 종료 시 적용됐던 스탯 초기화하는 기능 추가
fix: 플레이어 턴 종료 시 현재 코스트 회복

add: 코스트 부족으로 사용이 불가능한 카드의 드래그를 막는 기능 추가
add: 사용이 불가능한 카드의 색상을 회색으로 표시